### PR TITLE
Fix Vite build warning: suppress CSS URL resolution warning

### DIFF
--- a/src/prod.ts
+++ b/src/prod.ts
@@ -27,7 +27,7 @@ class N8nEmbeddedChatInterfaceElement extends HTMLElement {
 }
 
 // Load styles
-fetch(new URL("./styles/output.css", import.meta.url))
+fetch(new URL(/* @vite-ignore */ "./index.css", import.meta.url))
 	.then((res) => res.text())
 	.then((css) => {
 		class N8nEmbeddedChatInterfaceElementWithStyles extends N8nEmbeddedChatInterfaceElement {


### PR DESCRIPTION
## 🔧 **Problem**

During the production build process, Vite was showing this warning:
```
new URL("./styles/output.css", import.meta.url) doesn't exist at build time, it will remain unchanged to be resolved at runtime. If this is intended, you can use the /* @vite-ignore */ comment to suppress this warning.
```

## 🎯 **Root Cause**

The code in `src/prod.ts` was trying to fetch CSS from `./styles/output.css`, but the actual built CSS file is located at `./index.css` in the output directory.

## ✅ **Solution**

1. **Fixed CSS path**: Changed from `./styles/output.css` → `./index.css` to match the actual build output
2. **Suppressed warning**: Added `/* @vite-ignore */` comment to indicate this is intentional runtime behavior
3. **Verified functionality**: Confirmed build works perfectly with no warnings

## 📝 **Changes Made**

```typescript
// Before:
fetch(new URL("./styles/output.css", import.meta.url))

// After:
fetch(new URL(/* @vite-ignore */ "./index.css", import.meta.url))
```

## 🧪 **Testing**

- ✅ Build completes without warnings
- ✅ Generates correct output files (`index.css`, `index.umd.cjs`)
- ✅ Server starts and runs correctly
- ✅ CSS is loaded dynamically at runtime as intended

## 🚀 **Impact**

- **Build Process**: Clean build with no warnings
- **Deployment**: Ready for production deployment on Render
- **Functionality**: No breaking changes, CSS loading works as expected

This fix ensures a clean build process for production deployment while maintaining the intended runtime CSS loading behavior.

@TradieMate can click here to [continue refining the PR](https://app.all-hands.dev/c8e60693eec64d0ca8b6205e8c9d8744)