### PR TITLE
Fix Render deployment: serve HTML landing page instead of JS bundle

### DIFF
--- a/production-demo.html
+++ b/production-demo.html
@@ -109,7 +109,7 @@
             
             <h3>🔗 Integration Code:</h3>
             <p>To embed this chat widget on your website, add this code:</p>
-            <pre style="background: #f4f4f4; padding: 15px; border-radius: 8px; overflow-x: auto;"><code>&lt;script src="https://your-render-url.onrender.com/index.umd.cjs"&gt;&lt;/script&gt;
+            <pre style="background: #f4f4f4; padding: 15px; border-radius: 8px; overflow-x: auto;"><code>&lt;script src="https://your-render-url.onrender.com/widget.js"&gt;&lt;/script&gt;
 &lt;n8n-embedded-chat-interface 
     label="TradieMate Assistant" 
     hostname="YOUR_PRODUCTION_N8N_WEBHOOK_URL" 
@@ -119,7 +119,7 @@
     </div>
 
     <!-- N8N Chat Interface -->
-    <script src="./index.umd.cjs"></script>
+    <script src="./widget.js"></script>
     <n8n-embedded-chat-interface 
         label="TradieMate Assistant" 
         hostname="http://localhost:5678/webhook/9ef3e72d-7bec-4ca7-9223-3d323f42a950/chat" 

--- a/server.js
+++ b/server.js
@@ -19,12 +19,22 @@ app.use((req, res, next) => {
 // Serve static files from output directory
 app.use(express.static(path.join(__dirname, 'output')));
 
-// Serve the main UMD file
+// Serve the production demo page as the main landing page
 app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'production-demo.html'));
+});
+
+// Serve the widget script at a dedicated endpoint
+app.get('/widget.js', (req, res) => {
   res.sendFile(path.join(__dirname, 'output', 'index.umd.cjs'));
 });
 
-// Serve demo page
+// Also serve it at the original path for backward compatibility
+app.get('/index.umd.cjs', (req, res) => {
+  res.sendFile(path.join(__dirname, 'output', 'index.umd.cjs'));
+});
+
+// Serve demo page (same as root now)
 app.get('/demo', (req, res) => {
   res.sendFile(path.join(__dirname, 'production-demo.html'));
 });
@@ -41,6 +51,8 @@ app.get('/health', (req, res) => {
 
 app.listen(port, '0.0.0.0', () => {
   console.log(`N8N Chat Interface server listening on port ${port}`);
-  console.log(`Demo available at: http://localhost:${port}/demo`);
-  console.log(`Widget script at: http://localhost:${port}/index.umd.cjs`);
+  console.log(`Landing page: http://localhost:${port}/`);
+  console.log(`Demo page: http://localhost:${port}/demo`);
+  console.log(`Widget script: http://localhost:${port}/widget.js`);
+  console.log(`Legacy script: http://localhost:${port}/index.umd.cjs`);
 });


### PR DESCRIPTION
## Problem
When visiting the Render deployment URL, users were getting a raw JavaScript file instead of a proper HTML landing page. This made the application appear broken and unprofessional.

## Root Cause
The Express server was misconfigured for a frontend web application:
- The root route (`/`) was serving the raw UMD JavaScript bundle (`index.umd.cjs`) directly
- This caused browsers to download or display raw JavaScript code instead of rendering an HTML page
- No proper landing page was available to showcase the chat widget

## Solution
Reconfigured the server routes to properly serve a frontend web application:

### Changes Made:
1. **Root route now serves HTML**: Changed `/` to serve `production-demo.html` instead of the JS bundle
2. **Dedicated widget endpoint**: Added `/widget.js` route for the JavaScript bundle
3. **Backward compatibility**: Maintained `/index.umd.cjs` route for existing integrations
4. **Updated references**: Updated `production-demo.html` to use the new script path
5. **Improved logging**: Updated console output to reflect the new route structure

### New Route Structure:
- `/` → Serves HTML landing page with embedded chat widget demo
- `/widget.js` → Serves the JavaScript bundle for embedding
- `/index.umd.cjs` → Legacy path (backward compatibility)
- `/demo` → Same as root (alias)

## Result
- ✅ Visiting the Render URL now shows a professional HTML landing page
- ✅ Chat widget is properly embedded and functional on the landing page
- ✅ Clear integration instructions are displayed
- ✅ JavaScript bundle is available at a clean `/widget.js` endpoint
- ✅ Backward compatibility maintained for existing integrations

## Testing
- [x] Verified HTML page loads correctly at root URL
- [x] Confirmed chat widget displays and functions properly
- [x] Tested JavaScript bundle is accessible at `/widget.js`
- [x] Verified backward compatibility with `/index.umd.cjs`

## Files Changed
- `server.js` - Updated route configuration and console logging
- `production-demo.html` - Updated script reference paths

@TradieMate can click here to [continue refining the PR](https://app.all-hands.dev/6fca7efb781440019ea02328f48affa6)